### PR TITLE
Update to use getBooleanInput

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ try {
 		const universeId = core.getInput('universeId');
 		const placeId = core.getInput('placeId');
 		const filePath = core.getInput('file');
-		const shouldPublish = core.getInput('shouldPublish');
+		const shouldPublish = core.getBooleanInput('shouldPublish');
 
 		const validPath = fs.existsSync(filePath);
 


### PR DESCRIPTION
In `@actions/core`, `getInput` now always returns a string, which causes `shouldPublish` to always resolve to true. This causes side effects like #3 where it will always set versionType to Published. This PR makes `shouldPublish` be retrieved with `getBooleanInput`, which returns a boolean.